### PR TITLE
インデントが無効化されないように文字列処理を変更

### DIFF
--- a/src/utils/dhon_loader.js
+++ b/src/utils/dhon_loader.js
@@ -42,7 +42,7 @@ const dhon_loader = ((dihn) => {
                     break;
                 }
                 
-                const chat_line = line.match(/^([^\s]*)\s*:\s*(.*)$/)
+                const chat_line = line.match(/^([^\s]*)\s*:\s?(.*)$/)
                 if (chat_line !== null) {
                     if (chat_line[1] !== "" || chat === null) {
                         if (doc === null) add_doc("");


### PR DESCRIPTION
https://github.com/GakuseiGuildTextbooks/textbook-devkit/issues/2
行頭の空白が無効化されるようになっていたため，文字列の処理を変更しました．