### PR TITLE
コース名に二桁以上の数字が存在する場合に正しくソートされない問題を修正

### DIFF
--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -67,7 +67,7 @@ import axios from 'axios'
         let lessons = res.data.filter((item) => {
           return 	/^\d*$/.test(item)
         })
-        lessons = lessons.map((item) => Number(item))
+        lessons = lessons.map((item) => Number(item)).sort((a, b) => a - b)
         this.lessons = lessons
       })
     }


### PR DESCRIPTION
二桁以上の数字が存在する場合に正しくソートされない問題を修正します．

## 例
### 修正前
```
第1講
第10講
第2講
```

### 修正後
```
第1講
第2講
第10講
```